### PR TITLE
bot sends server name instead of server ID when main.py starts

### DIFF
--- a/cogs/wel.py
+++ b/cogs/wel.py
@@ -82,8 +82,14 @@ class GNCommands(commands.Cog):
                                 cursor = alliance_db.cursor()
                                 cursor.execute("SELECT discord_server_id FROM alliance_list WHERE alliance_id = ?", (alliance_id,))
                                 discord_server = cursor.fetchone()
-                                if discord_server and discord_server[0]:
-                                    info_parts.append(f"🌐 Server ID: {discord_server[0]}")
+                                if discord_server:
+                                    server_id = discord_server[0]
+                                    if server_id:
+                                        guild = self.bot.get_guild(server_id)
+                                        if guild:
+                                            info_parts.append(f"🌐 Server Name: {guild.name}")
+                                        else:
+                                            info_parts.append(f"🌐 Server ID: {server_id}")
                             
                                 cursor.execute("SELECT channel_id, interval FROM alliancesettings WHERE alliance_id = ?", (alliance_id,))
                                 settings = cursor.fetchone()


### PR DESCRIPTION
update wel.py -->defaults to server name first and if it cant be found it will send the server ID

update alliance.py--> "View alliances" used to show all alliances if you're the initial admin and only alliances created 
                                   on the current server if you're a regular admin. Now, if you're a regular admin that is assigned 
                                   an alliance created on another server you can see it when clicking on the button so matter 
                                   which server you're running the command on.

                                   "check alliances" used to show all alliances for initial and regular admins, now it show all 
                                   alliances to initial admin and only assigned alliances to regular admins