### PR TITLE
Add support for environment variables for Docker and automation compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  wos-discord-bot:
+    image: python:3.12.4-alpine
+    container_name: wos-discord-bot
+    environment:
+      - BOT_TOKEN=pasteHereYourDiscordBotToken
+      - AUTO_UPDATE=false # set to true, if you want to automatically update after restarting container
+    volumes:
+      - ./:/app
+    working_dir: /app
+    command: python main.py
+    restart: unless-stopped

--- a/main.py
+++ b/main.py
@@ -165,10 +165,25 @@ if __name__ == "__main__":
                     if main_py_updated:
                         print(Fore.YELLOW + "\nNOTE: This update includes changes to main.py. Bot will restart after update." + Style.RESET_ALL)
 
-                    response = input("\nDo you want to update now? (y/n): ").lower()
+                    auto_update_env = os.getenv('AUTO_UPDATE')
+                    if auto_update_env is not None:
+                        auto_update = auto_update_env.lower() == 'true'
+                        print(f"AUTO_UPDATE is set to {'true' if auto_update else 'false'}.")
+                    else:
+                        auto_update = None
+
+                    if auto_update is True:
+                        print("Auto-update enabled. Proceeding with update...")
+                        response = 'y'
+                    elif auto_update is False:
+                        print("Auto-update disabled. Skipping update.")
+                        response = 'n'
+                    else:
+                        response = input("\nDo you want to update now? (y/n): ").lower()
+
                     if response == 'y':
                         needs_restart = False
-                        
+
                         for file_name, new_version in updates_needed:
                             if file_name.strip() != 'main.py':
                                 file_url = f"{source_url}/{file_name}"
@@ -241,14 +256,16 @@ if __name__ == "__main__":
 
     init(autoreset=True)
 
+    bot_token = os.getenv('BOT_TOKEN')
     token_file = 'bot_token.txt'
-    if not os.path.exists(token_file):
-        bot_token = input("Enter the bot token: ")
-        with open(token_file, 'w') as f:
-            f.write(bot_token)
-    else:
-        with open(token_file, 'r') as f:
-            bot_token = f.read().strip()
+    if not bot_token:
+        if not os.path.exists(token_file):
+            bot_token = input("Enter the bot token: ")
+            with open(token_file, 'w') as f:
+                f.write(bot_token)
+        else:
+            with open(token_file, 'r') as f:
+                bot_token = f.read().strip()
 
     if not os.path.exists('db'):
         os.makedirs('db')


### PR DESCRIPTION
This PR improves automation compatibility by introducing support for environment variables, making the bot easier to use in Docker containers or other non-interactive environments (e.g. cronjobs). Suggestion in Discord: https://discord.com/channels/1302750463904579665/1353538974970544208

## Changes:
-  `AUTO_UPDATE` environment variable added:
- `AUTO_UPDATE=true` → automatically applies updates without user input.
- `AUTO_UPDATE=false` → skips updates silently.
- Not set → falls back to interactive prompt as before.
- Clear console messages indicate how `AUTO_UPDATE` is interpreted.
- `BOT_TOKEN` can now be provided via environment (`BOT_TOKEN=...`) instead of always requiring `bot_token.txt` or user input.
- Behavior remains backward compatible for local/interactively run scripts.
- Docker support example added in docker-compose.yaml:


## Benefits:
- Compatible with Docker, systemd, and crontab jobs.
- Avoids blocking prompts in automated setups.
- Easier installation

